### PR TITLE
remove service names from the logger logs and use method name instead

### DIFF
--- a/interceptors.go
+++ b/interceptors.go
@@ -29,8 +29,8 @@ func NewInterceptor(service string, logger *zap.SugaredLogger, options ...Interc
 
 	//apply default interceptors
 	WithInterecptor(kitgrpc.Interceptor)(in)
-	WithInterecptor(loggingInterceptor(service, logger))(in)
-	WithInterecptor(recoveryInterceptor(service, logger))(in)
+	WithInterecptor(loggingInterceptor(logger))(in)
+	WithInterecptor(recoveryInterceptor(logger))(in)
 
 	for _, option := range options {
 		option(in)

--- a/logger.go
+++ b/logger.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func loggingInterceptor(service string, logger *zap.SugaredLogger) grpc.UnaryServerInterceptor {
+func loggingInterceptor(logger *zap.SugaredLogger) grpc.UnaryServerInterceptor {
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
 		// log request and response data
@@ -18,9 +18,9 @@ func loggingInterceptor(service string, logger *zap.SugaredLogger) grpc.UnarySer
 		request := fmt.Sprintf("%+v", req)
 		method := getMethod(info)
 
-		logger.Debugw(service, "method", method, "request", request)
+		logger.Debugw(method, "method", method, "request", request)
 		resp, err := handler(ctx, req)
-		logger.Infow(service, "method", method, "request", request, "response", resp, "error", err, "took", time.Since(begin))
+		logger.Infow(method, "method", method, "request", request, "response", resp, "error", err, "took", time.Since(begin))
 		return resp, err
 	}
 }

--- a/recover.go
+++ b/recover.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func recoveryInterceptor(service string, logger *zap.SugaredLogger) grpc.UnaryServerInterceptor {
+func recoveryInterceptor(logger *zap.SugaredLogger) grpc.UnaryServerInterceptor {
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
 		panicked := true


### PR DESCRIPTION
# why

Use of service name as logger message will just clutter the log with uneventful message. 
use method name instead