### PR TITLE
Add log method skipper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gogo/status v1.1.0
 	github.com/google/uuid v1.1.2
 	github.com/netbookai/log v0.4.0
-	go.uber.org/zap v1.19.1
 	google.golang.org/grpc v1.44.0
 )
 
@@ -18,6 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -445,7 +445,6 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -54,3 +54,16 @@ func Test_GetInterceptors(t *testing.T) {
 		t.Fatalf("GetInterceptors :  type missmatch, expected 'grpc.ServerOption', got '%s'", got)
 	}
 }
+
+func Test_skipLog(t *testing.T) {
+	in := &interceptor{}
+	WithSkipMethod([]string{"password"})(in)
+
+	if !in.skipLog("password") {
+		t.Fatalf("skipLog: expected : true, Got : false")
+	}
+
+	if in.skipLog("ping") {
+		t.Fatalf("skipLog: expected : false, Got :true")
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -19,6 +19,7 @@ func loggingInterceptor(in *interceptor, logger log.Logger) grpc.UnaryServerInte
 		method := getMethod(info)
 
 		skip := in.skipLog(method)
+
 		args := []interface{}{method, "method", method}
 		if !skip {
 			args = append(args, []interface{}{"request", request})
@@ -28,10 +29,10 @@ func loggingInterceptor(in *interceptor, logger log.Logger) grpc.UnaryServerInte
 		resp, err := handler(ctx, req)
 
 		args = []interface{}{method, "method", method, "error", err, "took", time.Since(begin)}
-
 		if !skip {
-			args = append(args, []interface{}{"request", request, request, "response", resp})
+			args = append(args, []interface{}{"request", request, "response", resp})
 		}
+
 		logger.Info(ctx, args...)
 		return resp, err
 	}

--- a/recover.go
+++ b/recover.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func recoveryInterceptor(logger log.Logger) grpc.UnaryServerInterceptor {
+func recoveryInterceptor(in *interceptor, logger log.Logger) grpc.UnaryServerInterceptor {
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
 		panicked := true


### PR DESCRIPTION
Allow user to skip request and response of sensitive api/gRPC method.

usage:

```
var skipMethods = []string{"ReadCredential", "WriteCredential"}
interceptors := interceptors.NewInterceptor("spawnerservice",
	logger,
	interceptors.WithInterecptor(metrics.RPCInstrumentation()),
	interceptors.WithSkipMethod(skipMethods))

```